### PR TITLE
1주차 과제

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,11 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleHome" value="" />
-        <option name="gradleJvm" value="#JAVA_HOME" />
+        <option name="gradleJvm" value="temurin-17" />
+        <option name="modules">
+          <set>
+            <option value="$PROJECT_DIR$" />
+          </set>
+        </option>
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" project-jdk-name="temurin-17" project-jdk-type="JavaSDK">
+  <component name="FrameworkDetectionExcludesConfiguration">
+    <file type="web" url="file://$PROJECT_DIR$" />
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="temurin-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/src/main/java/org/sopt/Main.java
+++ b/src/main/java/org/sopt/Main.java
@@ -23,8 +23,13 @@ public class Main {
           System.out.println("\n📝 [게시글 작성]");
           System.out.print("📌 제목을 입력해주세요: ");
           String title = scanner.nextLine();
-          controller.createPost(title);
-          System.out.println("✅ 게시글이 성공적으로 저장되었습니다!");
+
+          try {
+            controller.createPost(title);
+            System.out.println("✅ 게시글이 성공적으로 저장되었습니다!");
+          } catch (IllegalArgumentException e) {
+            System.out.println("❌ 입력 오류! " + e.getMessage());
+          }
           break;
 
         case "2":
@@ -56,11 +61,17 @@ public class Main {
           int updateId = Integer.parseInt(scanner.nextLine());
           System.out.print("📝 새 제목을 입력해주세요: ");
           String newTitle = scanner.nextLine();
-          boolean updated = controller.updatePostTitle(updateId, newTitle);
-          if (updated) {
-            System.out.println("✅ 게시글이 성공적으로 수정되었습니다.");
-          } else {
-            System.out.println("❌ 해당 ID의 게시글이 존재하지 않습니다.");
+
+          try {
+
+            boolean updated = controller.updatePostTitle(updateId, newTitle);
+            if (updated) {
+              System.out.println("✅ 게시글이 성공적으로 수정되었습니다.");
+            } else {
+              System.out.println("❌ 해당 ID의 게시글이 존재하지 않습니다.");
+            }
+          } catch (IllegalArgumentException e) {
+            System.out.println("❌ 입력 오류! " + e.getMessage());
           }
           break;
 

--- a/src/main/java/org/sopt/Main.java
+++ b/src/main/java/org/sopt/Main.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Scanner;
 import org.sopt.controller.PostController;
 import org.sopt.domain.Post;
+import org.sopt.util.PostFileHandler;
 
 public class Main {
   public static void main(String[] args) {
@@ -102,6 +103,24 @@ public class Main {
           }
           break;
 
+        case "7":
+          System.out.println("\n📀 [게시글 파일에 저장]");
+          PostFileHandler.savePosts(controller.getAllPosts());
+          System.out.println("✅ 게시글이 파일에 저장되었습니다.");
+          break;
+
+        case "8":
+          List<Post> savedPosts = PostFileHandler.loadPosts();
+          if (savedPosts.isEmpty()) {
+            System.out.println("❗️파일에 저장된 게시글이 없습니다.");
+          } else {
+            System.out.println("📁 파일에 저장된 게시글 목록");
+            for (Post post : savedPosts) {
+              System.out.println("id: " + post.getId() + " | title: " + post.getTitle());
+            }
+          }
+          break;
+
         case "0":
           System.out.println("\n👋 프로그램을 종료합니다. 감사합니다!");
           return;
@@ -126,6 +145,8 @@ public class Main {
     System.out.println("4️⃣  게시글 수정");
     System.out.println("5️⃣  게시글 삭제");
     System.out.println("6️⃣  게시글 검색");
+    System.out.println("7️⃣  게시글 파일에 저장");
+    System.out.println("8️⃣  게시글 목록 파일에서 불러오기");
     System.out.println("0️⃣  프로그램 종료");
     System.out.println("=====================================");
   }

--- a/src/main/java/org/sopt/Main.java
+++ b/src/main/java/org/sopt/Main.java
@@ -4,9 +4,9 @@ import java.util.List;
 import java.util.Scanner;
 import org.sopt.controller.PostController;
 import org.sopt.domain.Post;
-import org.sopt.util.PostFileHandler;
 
 public class Main {
+
   public static void main(String[] args) {
     Scanner scanner = new Scanner(System.in);
     PostController controller = new PostController();
@@ -24,13 +24,8 @@ public class Main {
           System.out.println("\n📝 [게시글 작성]");
           System.out.print("📌 제목을 입력해주세요: ");
           String title = scanner.nextLine();
-
-          try {
-            controller.createPost(title);
-            System.out.println("✅ 게시글이 성공적으로 저장되었습니다!");
-          } catch (IllegalArgumentException e) {
-            System.out.println("❌ 입력 오류! " + e.getMessage());
-          }
+          controller.createPost(title);
+          System.out.println("✅ 게시글이 성공적으로 저장되었습니다!");
           break;
 
         case "2":
@@ -62,17 +57,11 @@ public class Main {
           int updateId = Integer.parseInt(scanner.nextLine());
           System.out.print("📝 새 제목을 입력해주세요: ");
           String newTitle = scanner.nextLine();
-
-          try {
-
-            boolean updated = controller.updatePostTitle(updateId, newTitle);
-            if (updated) {
-              System.out.println("✅ 게시글이 성공적으로 수정되었습니다.");
-            } else {
-              System.out.println("❌ 해당 ID의 게시글이 존재하지 않습니다.");
-            }
-          } catch (IllegalArgumentException e) {
-            System.out.println("❌ 입력 오류! " + e.getMessage());
+          boolean updated = controller.updatePostTitle(updateId, newTitle);
+          if (updated) {
+            System.out.println("✅ 게시글이 성공적으로 수정되었습니다.");
+          } else {
+            System.out.println("❌ 해당 ID의 게시글이 존재하지 않습니다.");
           }
           break;
 
@@ -103,24 +92,6 @@ public class Main {
           }
           break;
 
-        case "7":
-          System.out.println("\n📀 [게시글 파일에 저장]");
-          PostFileHandler.savePosts(controller.getAllPosts());
-          System.out.println("✅ 게시글이 파일에 저장되었습니다.");
-          break;
-
-        case "8":
-          List<Post> savedPosts = PostFileHandler.loadPosts();
-          if (savedPosts.isEmpty()) {
-            System.out.println("❗️파일에 저장된 게시글이 없습니다.");
-          } else {
-            System.out.println("📁 파일에 저장된 게시글 목록");
-            for (Post post : savedPosts) {
-              System.out.println("id: " + post.getId() + " | title: " + post.getTitle());
-            }
-          }
-          break;
-
         case "0":
           System.out.println("\n👋 프로그램을 종료합니다. 감사합니다!");
           return;
@@ -145,8 +116,6 @@ public class Main {
     System.out.println("4️⃣  게시글 수정");
     System.out.println("5️⃣  게시글 삭제");
     System.out.println("6️⃣  게시글 검색");
-    System.out.println("7️⃣  게시글 파일에 저장");
-    System.out.println("8️⃣  게시글 목록 파일에서 불러오기");
     System.out.println("0️⃣  프로그램 종료");
     System.out.println("=====================================");
   }

--- a/src/main/java/org/sopt/Main.java
+++ b/src/main/java/org/sopt/Main.java
@@ -1,8 +1,121 @@
 package org.sopt;
 
-public class Main {
+import java.util.List;
+import java.util.Scanner;
+import org.sopt.controller.PostController;
+import org.sopt.domain.Post;
 
+public class Main {
   public static void main(String[] args) {
-    System.out.println("Hello world!");
+    Scanner scanner = new Scanner(System.in);
+    PostController controller = new PostController();
+
+    printWelcome();
+
+    while (true) {
+      printMenu();
+
+      System.out.print("👉 선택: ");
+      String input = scanner.nextLine();
+
+      switch (input) {
+        case "1":
+          System.out.println("\n📝 [게시글 작성]");
+          System.out.print("📌 제목을 입력해주세요: ");
+          String title = scanner.nextLine();
+          controller.createPost(title);
+          System.out.println("✅ 게시글이 성공적으로 저장되었습니다!");
+          break;
+
+        case "2":
+          System.out.println("\n📚 [전체 게시글 조회]");
+          for (Post post : controller.getAllPosts()) {
+            System.out.printf("🆔 %d | 📌 제목: %s\n", post.getId(), post.getTitle());
+          }
+          break;
+
+        case "3":
+          System.out.println("\n🔍 [게시글 상세 조회]");
+          System.out.print("📌 조회할 게시글 ID를 입력해주세요: ");
+          int id = Integer.parseInt(scanner.nextLine());
+          Post found = controller.getPostById(id);
+          if (found != null) {
+            System.out.println("📄 게시글 상세 내용:");
+            System.out.println("-------------------------------------");
+            System.out.printf("🆔 ID: %d\n", found.getId());
+            System.out.printf("📌 제목: %s\n", found.getTitle());
+            System.out.println("-------------------------------------");
+          } else {
+            System.out.println("❌ 해당 ID의 게시글이 존재하지 않습니다.");
+          }
+          break;
+
+        case "4":
+          System.out.println("\n✏️ [게시글 수정]");
+          System.out.print("📌 수정할 게시글 ID를 입력해주세요: ");
+          int updateId = Integer.parseInt(scanner.nextLine());
+          System.out.print("📝 새 제목을 입력해주세요: ");
+          String newTitle = scanner.nextLine();
+          boolean updated = controller.updatePostTitle(updateId, newTitle);
+          if (updated) {
+            System.out.println("✅ 게시글이 성공적으로 수정되었습니다.");
+          } else {
+            System.out.println("❌ 해당 ID의 게시글이 존재하지 않습니다.");
+          }
+          break;
+
+        case "5":
+          System.out.println("\n🗑️ [게시글 삭제]");
+          System.out.print("📌 삭제할 게시글 ID를 입력해주세요: ");
+          int deleteId = Integer.parseInt(scanner.nextLine());
+          boolean deleted = controller.deletePostById(deleteId);
+          if (deleted) {
+            System.out.println("🗑️ 게시글이 성공적으로 삭제되었습니다.");
+          } else {
+            System.out.println("❌ 삭제할 게시글이 존재하지 않습니다.");
+          }
+          break;
+
+        case "6":
+          System.out.println("\n🔎 [게시글 검색]");
+          System.out.print("검색할 키워드를 입력해주세요: ");
+          String keyword = scanner.nextLine();
+          List<Post> results = controller.searchPostsByKeyword(keyword);
+          if (results.isEmpty()) {
+            System.out.println("🔍 검색 결과가 없습니다.");
+          } else {
+            System.out.println("📋 검색 결과:");
+            for (Post post : results) {
+              System.out.printf("🆔 %d | 📌 제목: %s\n", post.getId(), post.getTitle());
+            }
+          }
+          break;
+
+        case "0":
+          System.out.println("\n👋 프로그램을 종료합니다. 감사합니다!");
+          return;
+
+        default:
+          System.out.println("⚠️ 잘못된 입력입니다. 다시 시도해주세요.");
+      }
+    }
+  }
+
+  private static void printWelcome() {
+    System.out.println("=====================================");
+    System.out.println("📌  자바 게시판 프로그램에 오신 것을 환영합니다!");
+    System.out.println("=====================================\n");
+  }
+
+  private static void printMenu() {
+    System.out.println("\n================ 메뉴 ================");
+    System.out.println("1️⃣  게시글 작성");
+    System.out.println("2️⃣  전체 게시글 조회");
+    System.out.println("3️⃣  게시글 상세 조회");
+    System.out.println("4️⃣  게시글 수정");
+    System.out.println("5️⃣  게시글 삭제");
+    System.out.println("6️⃣  게시글 검색");
+    System.out.println("0️⃣  프로그램 종료");
+    System.out.println("=====================================");
   }
 }

--- a/src/main/java/org/sopt/controller/PostController.java
+++ b/src/main/java/org/sopt/controller/PostController.java
@@ -16,18 +16,19 @@ public class PostController {
     return postService.getAllPosts();
   }
 
-  public Post getPostById(int id) {
+  public Post getPostById(final int id) {
     return postService.getPostById(id);
   }
-  public Boolean updatePostTitle(int id, String newTitle) {
-    return null;
+
+  public Boolean updatePostTitle(final int id, final String newTitle) {
+    return postService.updatePostTitle(id, newTitle);
   }
 
-  public boolean deletePostById(int id) {
+  public boolean deletePostById(final int id) {
     return postService.deletePostById(id);
   }
 
-  public List<Post> searchPostsByKeyword(String keyword) {
+  public List<Post> searchPostsByKeyword(final String keyword) {
     return null;
   }
 

--- a/src/main/java/org/sopt/controller/PostController.java
+++ b/src/main/java/org/sopt/controller/PostController.java
@@ -1,35 +1,64 @@
 package org.sopt.controller;
 
+import java.util.Collections;
+import java.util.List;
 import org.sopt.domain.Post;
 import org.sopt.service.PostService;
 
-import java.util.List;
-
 public class PostController {
+
   private final PostService postService = new PostService();
 
   public void createPost(final String title) {
-    postService.createPost(title);
+    try {
+      postService.createPost(title);
+    } catch (IllegalArgumentException e) {
+      System.out.println("❌ 게시글 작성 실패: " + e.getMessage());
+    }
   }
 
   public List<Post> getAllPosts() {
-    return postService.getAllPosts();
+    try {
+      return postService.getAllPosts();
+    } catch (Exception e) {
+      System.out.println("❌ 게시글 목록 조회 실패: " + e.getMessage());
+      return Collections.emptyList();
+    }
   }
 
   public Post getPostById(final int id) {
-    return postService.getPostById(id);
+    try {
+      return postService.getPostById(id);
+    } catch (Exception e) {
+      System.out.println("❌ 게시글 조회 실패: " + e.getMessage());
+      return null;
+    }
   }
 
   public Boolean updatePostTitle(final int id, final String newTitle) {
-    return postService.updatePostTitle(id, newTitle);
+    try {
+      return postService.updatePostTitle(id, newTitle);
+    } catch (IllegalArgumentException e) {
+      System.out.println("❌ 게시글 수정 실패: " + e.getMessage());
+      return false;
+    }
   }
 
   public boolean deletePostById(final int id) {
-    return postService.deletePostById(id);
+    try {
+      return postService.deletePostById(id);
+    } catch (Exception e) {
+      System.out.println("❌ 게시글 삭제 실패: " + e.getMessage());
+      return false;
+    }
   }
 
   public List<Post> searchPostsByKeyword(final String keyword) {
-    return postService.searchPostsByKeyword(keyword);
+    try {
+      return postService.searchPostsByKeyword(keyword);
+    } catch (Exception e) {
+      System.out.println("❌ 게시글 검색 실패: " + e.getMessage());
+      return Collections.emptyList();
+    }
   }
-
 }

--- a/src/main/java/org/sopt/controller/PostController.java
+++ b/src/main/java/org/sopt/controller/PostController.java
@@ -29,7 +29,7 @@ public class PostController {
   }
 
   public List<Post> searchPostsByKeyword(final String keyword) {
-    return null;
+    return postService.searchPostsByKeyword(keyword);
   }
 
 }

--- a/src/main/java/org/sopt/controller/PostController.java
+++ b/src/main/java/org/sopt/controller/PostController.java
@@ -1,0 +1,34 @@
+package org.sopt.controller;
+
+import org.sopt.domain.Post;
+import org.sopt.service.PostService;
+
+import java.util.List;
+
+public class PostController {
+  private final PostService postService = new PostService();
+
+  public void createPost(final String title) {
+    postService.createPost(title);
+  }
+
+  public List<Post> getAllPosts() {
+    return postService.getAllPosts();
+  }
+
+  public Post getPostById(int id) {
+    return postService.getPostById(id);
+  }
+  public Boolean updatePostTitle(int id, String newTitle) {
+    return null;
+  }
+
+  public boolean deletePostById(int id) {
+    return postService.deletePostById(id);
+  }
+
+  public List<Post> searchPostsByKeyword(String keyword) {
+    return null;
+  }
+
+}

--- a/src/main/java/org/sopt/domain/Post.java
+++ b/src/main/java/org/sopt/domain/Post.java
@@ -16,4 +16,8 @@ public class Post {
   public String getTitle() {
     return this.title;
   }
+
+  public void setTitle(String title) {
+    this.title = title;
+  }
 }

--- a/src/main/java/org/sopt/domain/Post.java
+++ b/src/main/java/org/sopt/domain/Post.java
@@ -1,6 +1,7 @@
 package org.sopt.domain;
 
 public class Post {
+
   private int id;
   private String title;
 

--- a/src/main/java/org/sopt/domain/Post.java
+++ b/src/main/java/org/sopt/domain/Post.java
@@ -1,0 +1,19 @@
+package org.sopt.domain;
+
+public class Post {
+  private int id;
+  private String title;
+
+  public Post(int id, String title) {
+    this.id = id;
+    this.title = title;
+  }
+
+  public int getId() {
+    return this.id;
+  }
+
+  public String getTitle() {
+    return this.title;
+  }
+}

--- a/src/main/java/org/sopt/repository/PostRepository.java
+++ b/src/main/java/org/sopt/repository/PostRepository.java
@@ -35,4 +35,14 @@ public class PostRepository {
     }
     return false;
   }
+
+  public Boolean update(int id, String newTitle) {
+    for (Post post : postList) {
+      if (post.getId() == id) {
+        post.setTitle(newTitle);
+        return true;
+      }
+    }
+    return false;
+  }
 }

--- a/src/main/java/org/sopt/repository/PostRepository.java
+++ b/src/main/java/org/sopt/repository/PostRepository.java
@@ -1,0 +1,38 @@
+package org.sopt.repository;
+
+import org.sopt.domain.Post;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PostRepository {
+  List<Post> postList = new ArrayList<>();
+
+  public void save(Post post) {
+    postList.add(post);
+  }
+
+  public List<Post> findAll() {
+    return postList;
+  }
+
+  public Post findPostById(int id) {
+    for (Post post : postList) {
+      if (post.getId() == id) {
+        return post;
+      }
+    }
+
+    return null;
+  }
+
+  public boolean delete(int id) {
+    for (Post post : postList) {
+      if (post.getId() == id) {
+        postList.remove(post);
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/src/main/java/org/sopt/repository/PostRepository.java
+++ b/src/main/java/org/sopt/repository/PostRepository.java
@@ -1,12 +1,28 @@
 package org.sopt.repository;
 
-import org.sopt.domain.Post;
-
 import java.util.ArrayList;
 import java.util.List;
+import org.sopt.domain.Post;
+import org.sopt.util.PostFileHandler;
+import org.sopt.util.PostIdGenerator;
 
 public class PostRepository {
-  List<Post> postList = new ArrayList<>();
+
+  List<Post> postList;
+
+  public PostRepository() {
+    this.postList = PostFileHandler.loadPosts();
+
+    int maxId = 0;
+
+    for (Post post : postList) {
+      if (post.getId() > maxId) {
+        maxId = post.getId();
+      }
+    }
+
+    PostIdGenerator.initializedId(maxId + 1);
+  }
 
   public void save(Post post) {
     postList.add(post);

--- a/src/main/java/org/sopt/repository/PostRepository.java
+++ b/src/main/java/org/sopt/repository/PostRepository.java
@@ -1,6 +1,5 @@
 package org.sopt.repository;
 
-import java.util.ArrayList;
 import java.util.List;
 import org.sopt.domain.Post;
 import org.sopt.util.PostFileHandler;
@@ -26,9 +25,11 @@ public class PostRepository {
 
   public void save(Post post) {
     postList.add(post);
+    PostFileHandler.savePosts(postList);
   }
 
   public List<Post> findAll() {
+    postList = PostFileHandler.loadPosts();
     return postList;
   }
 
@@ -43,19 +44,26 @@ public class PostRepository {
   }
 
   public boolean delete(int id) {
+    boolean isMatched = false;
     for (Post post : postList) {
       if (post.getId() == id) {
         postList.remove(post);
-        return true;
+        isMatched = true;
       }
     }
-    return false;
+
+    if (isMatched) {
+      PostFileHandler.savePosts(postList);
+    }
+
+    return isMatched;
   }
 
   public Boolean update(int id, String newTitle) {
     for (Post post : postList) {
       if (post.getId() == id) {
         post.setTitle(newTitle);
+        PostFileHandler.savePosts(postList);
         return true;
       }
     }

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -2,6 +2,7 @@ package org.sopt.service;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import org.sopt.domain.Post;
 import org.sopt.repository.PostRepository;
 
@@ -59,5 +60,18 @@ public class PostService {
       }
     }
     return false;
+  }
+
+  public List<Post> searchPostsByKeyword(String keyword) {
+    List<Post> posts = postRepository.findAll();
+    List<Post> matchedPosts = new ArrayList<>();
+
+    for (Post post : posts) {
+      if (post.getTitle().contains(keyword)) {
+        matchedPosts.add(post);
+      }
+    }
+
+    return matchedPosts;
   }
 }

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -1,0 +1,29 @@
+package org.sopt.service;
+
+import org.sopt.domain.Post;
+import org.sopt.repository.PostRepository;
+
+import java.util.List;
+
+public class PostService {
+  private final PostRepository postRepository = new PostRepository();
+  private int postId = 1;
+
+  public void createPost(String title) {
+    Post post = new Post(postId++, title);
+
+    postRepository.save(post);
+  }
+
+  public List<Post> getAllPosts() {
+    return postRepository.findAll();
+  }
+
+  public Post getPostById(int id) {
+    return postRepository.findPostById(id);
+  }
+
+  public boolean deletePostById(int id) {
+    return postRepository.delete(id);
+  }
+}

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -4,18 +4,19 @@ import org.sopt.domain.Post;
 import org.sopt.repository.PostRepository;
 
 import java.util.List;
+import org.sopt.util.PostIdGenerator;
 import org.sopt.validator.PostValidator;
 
 public class PostService {
   private final PostRepository postRepository = new PostRepository();
-  private int postId = 1;
 
   public void createPost(String title) {
     PostValidator.validateTitle(title);
     if (isDuplicateTitle(title)) {
       throw new IllegalArgumentException("중복되는 제목은 등록할 수 없습니다.");
     }
-    Post post = new Post(postId++, title);
+    int id = PostIdGenerator.generateId();
+    Post post = new Post(id, title);
     postRepository.save(post);
   }
 

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -3,14 +3,14 @@ package org.sopt.service;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.List;
 import org.sopt.domain.Post;
 import org.sopt.repository.PostRepository;
-
-import java.util.List;
 import org.sopt.util.PostIdGenerator;
 import org.sopt.validator.PostValidator;
 
 public class PostService {
+
   private final PostRepository postRepository = new PostRepository();
   private LocalDateTime lastModifiedAt;
 

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -4,14 +4,15 @@ import org.sopt.domain.Post;
 import org.sopt.repository.PostRepository;
 
 import java.util.List;
+import org.sopt.validator.PostValidator;
 
 public class PostService {
   private final PostRepository postRepository = new PostRepository();
   private int postId = 1;
 
   public void createPost(String title) {
+    PostValidator.validateTitle(title);
     Post post = new Post(postId++, title);
-
     postRepository.save(post);
   }
 
@@ -28,6 +29,7 @@ public class PostService {
   }
 
   public Boolean updatePostTitle(int id, String newTitle) {
+    PostValidator.validateTitle(newTitle);
     return postRepository.update(id, newTitle);
   }
 }

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -12,6 +12,9 @@ public class PostService {
 
   public void createPost(String title) {
     PostValidator.validateTitle(title);
+    if (isDuplicateTitle(title)) {
+      throw new IllegalArgumentException("중복되는 제목은 등록할 수 없습니다.");
+    }
     Post post = new Post(postId++, title);
     postRepository.save(post);
   }
@@ -30,6 +33,20 @@ public class PostService {
 
   public Boolean updatePostTitle(int id, String newTitle) {
     PostValidator.validateTitle(newTitle);
+
+    if (isDuplicateTitle(newTitle)) {
+      throw new IllegalArgumentException("중복되는 제목은 등록할 수 없습니다.");
+    }
     return postRepository.update(id, newTitle);
+  }
+
+  public boolean isDuplicateTitle(final String title) {
+    List<Post> posts = postRepository.findAll();
+    for (Post post : posts) {
+      if (post.getTitle().equals(title)) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -26,4 +26,8 @@ public class PostService {
   public boolean deletePostById(int id) {
     return postRepository.delete(id);
   }
+
+  public Boolean updatePostTitle(int id, String newTitle) {
+    return postRepository.update(id, newTitle);
+  }
 }

--- a/src/main/java/org/sopt/util/PostFileHandler.java
+++ b/src/main/java/org/sopt/util/PostFileHandler.java
@@ -1,0 +1,54 @@
+package org.sopt.util;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.sopt.domain.Post;
+
+public class PostFileHandler {
+
+  private static final String FILE_PATH = "src/main/java/org/sopt/assets/Post.txt";
+
+  public static void savePosts(final List<Post> allPosts) {
+    try (BufferedWriter writer = new BufferedWriter(new FileWriter(FILE_PATH))) {
+      for (Post post : allPosts) {
+        writer.write("id: " + post.getId() + " | title: " + post.getTitle());
+        writer.newLine();
+      }
+    } catch (IOException e) {
+      System.out.println("❎ 파일 저장 중 오류가 발생했습니다: " + e.getMessage());
+    }
+  }
+
+  public static List<Post> loadPosts() {
+    List<Post> posts = new ArrayList<>();
+    File file = new File(FILE_PATH);
+
+    if (!file.exists()) return posts;
+
+    try (BufferedReader reader = new BufferedReader(new FileReader(FILE_PATH))) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        String[] split = line.split("\\|");
+
+        String idPart = split[0].trim();
+        int id = Integer.parseInt(idPart.substring(4));
+
+        String titlePart = split[1].trim();
+        String title = titlePart.substring(7);
+
+        posts.add(new Post(id, title));
+      }
+    } catch (IOException e) {
+      System.out.println("❎ 파일 로딩 중 오류가 발생했습니다: " + e.getMessage());
+    }
+
+    return posts;
+  }
+
+}

--- a/src/main/java/org/sopt/util/PostFileHandler.java
+++ b/src/main/java/org/sopt/util/PostFileHandler.java
@@ -29,11 +29,18 @@ public class PostFileHandler {
     List<Post> posts = new ArrayList<>();
     File file = new File(FILE_PATH);
 
-    if (!file.exists()) return posts;
+    if (!file.exists()) {
+      return posts;
+    }
 
     try (BufferedReader reader = new BufferedReader(new FileReader(FILE_PATH))) {
       String line;
       while ((line = reader.readLine()) != null) {
+
+        if (line.isBlank() || !line.contains("|")) {
+          continue;
+        }
+
         String[] split = line.split("\\|");
 
         String idPart = split[0].trim();

--- a/src/main/java/org/sopt/util/PostIdGenerator.java
+++ b/src/main/java/org/sopt/util/PostIdGenerator.java
@@ -1,6 +1,7 @@
 package org.sopt.util;
 
 public class PostIdGenerator {
+
   private static int id = 1;
 
   public static int generateId() {

--- a/src/main/java/org/sopt/util/PostIdGenerator.java
+++ b/src/main/java/org/sopt/util/PostIdGenerator.java
@@ -1,0 +1,9 @@
+package org.sopt.util;
+
+public class PostIdGenerator {
+  private static int id = 1;
+
+  public static int generateId() {
+    return id++;
+  }
+}

--- a/src/main/java/org/sopt/util/PostIdGenerator.java
+++ b/src/main/java/org/sopt/util/PostIdGenerator.java
@@ -6,4 +6,8 @@ public class PostIdGenerator {
   public static int generateId() {
     return id++;
   }
+
+  public static void initializedId(final int startId) {
+    id = startId;
+  }
 }

--- a/src/main/java/org/sopt/validator/PostValidator.java
+++ b/src/main/java/org/sopt/validator/PostValidator.java
@@ -1,10 +1,16 @@
 package org.sopt.validator;
 
 public class PostValidator {
+  private static final int MAX_TITLE_LENGTH = 30;
+
 
   public static void validateTitle(final String title) {
     if (title == null || title.isEmpty()) {
       throw new IllegalArgumentException("제목은 비어있을 수 없습니다.");
+    }
+
+    if (title.length() > MAX_TITLE_LENGTH) {
+      throw new IllegalArgumentException("제목은 30자를 넘을 수 없습니다.");
     }
   }
 }

--- a/src/main/java/org/sopt/validator/PostValidator.java
+++ b/src/main/java/org/sopt/validator/PostValidator.java
@@ -12,5 +12,7 @@ public class PostValidator {
     if (title.length() > MAX_TITLE_LENGTH) {
       throw new IllegalArgumentException("제목은 30자를 넘을 수 없습니다.");
     }
+
+
   }
 }

--- a/src/main/java/org/sopt/validator/PostValidator.java
+++ b/src/main/java/org/sopt/validator/PostValidator.java
@@ -1,18 +1,35 @@
 package org.sopt.validator;
 
-public class PostValidator {
-  private static final int MAX_TITLE_LENGTH = 30;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
+public class PostValidator {
+
+  private static final int MAX_TITLE_LENGTH = 30;
+  private static final Pattern GRAHEME_PATTERN = Pattern.compile("\\X");
 
   public static void validateTitle(final String title) {
     if (title == null || title.isEmpty()) {
       throw new IllegalArgumentException("제목은 비어있을 수 없습니다.");
     }
 
-    if (title.length() > MAX_TITLE_LENGTH) {
+    int graphemeLength = countGraphemeLength(title);
+    if (graphemeLength > MAX_TITLE_LENGTH) {
       throw new IllegalArgumentException("제목은 30자를 넘을 수 없습니다.");
     }
 
-
   }
+
+  private static int countGraphemeLength(final String title) {
+    Matcher matcher = GRAHEME_PATTERN.matcher(title);
+
+    int count = 0;
+
+    while (matcher.find()) {
+      count++;
+    }
+
+    return count;
+  }
+
 }

--- a/src/main/java/org/sopt/validator/PostValidator.java
+++ b/src/main/java/org/sopt/validator/PostValidator.java
@@ -1,0 +1,10 @@
+package org.sopt.validator;
+
+public class PostValidator {
+
+  public static void validateTitle(final String title) {
+    if (title == null || title.isEmpty()) {
+      throw new IllegalArgumentException("제목은 비어있을 수 없습니다.");
+    }
+  }
+}


### PR DESCRIPTION
# 📘 1주차 과제 제출 

## ✅ 필수 과제

- [x] 게시글 수정 기능을 추가해주세요.
- [x] 제목이 비어 있는 경우에는 게시글 작성이 되지 않게 해주세요.
- [x] 제목은 30자를 넘지 않게 해주세요.

---

## ✅ 선택 과제

- [x] 중복된 제목의 게시글은 작성되지 않게 해주세요.
- [x] ID 생성 책임을 따로 분리하여 유틸 클래스로 만들어주세요.  
- [x] 도배를 막기 위한 3분 제한 기능 구현  
- [x] 게시글 검색 기능을 추가해주세요.
- [x] 게시글을 파일로 저장하거나 불러올 수 있도록 해주세요.
  → 파일을 저장할 때 기존 내용을 덮어쓰는 방식으로 구현했습니다.  
  하지만 이 방식은 게시글 전체 리스트를 매번 다시 저장해야 하므로,  
  데이터 양이 많아질 경우 성능 부담이 생길 수 있다는 점이 고민되었습니다.
  예를 들어 특정 게시글 하나만 수정하거나 삭제해도  
  전체 파일을 통째로 덮어써야 하기 때문에 비효율적입니다.
  이를 개선하기 위해선  
  - 변경된 게시글만 갱신하는 방식 (부분 파일 수정)
  - 또는 JSON, CSV, 데이터베이스처럼 구조화된 포맷 사용
  등의 방법을 고려할 수 있겠지만, 이번 과제는 단순성을 고려하여 여기서 마무리하겠습니다.
- [x] 게시글 제목에 이모지를 허용하고, 이모지를 1글자로 계산되게 처리해주세요. (30자 제한 유지)  
  -> Java 17에서 지원되지 않는 grapheme cluster 처리를 위해 정규표현식 `\\X` 기반으로 구현했습니다.

---

## 📌 구현 참고 사항

- 게시글 작성, 수정, 삭제 시 자동으로 파일 저장
- 파일에서 로드한 게시글을 기준으로 메모리 리스트 초기화
- `PostValidator`를 통해 도메인 유효성 검사 책임 분리

---

## 💭 고민한 점

### 1. 이모지를 1글자로 인식하는 방법
Java에서 `String.length()`는 👨‍👩‍👧‍👦 같은 결합 이모지를 여러 글자로 인식합니다.  
처음에는 `BreakIterator`를 사용했지만 Java 17에서는 grapheme cluster를 완전히 지원하지 않아 실패했고,  
결국 정규 표현식 `\\X`를 활용하여 사용자가 보기엔 1글자인 이모지를 실제로도 1글자로 처리할 수 있도록 구현했습니다.  

### 2. 게시글 파일 저장/불러오기 방식
처음에는 메뉴에서 저장/불러오기를 수동으로 선택하는 방식이었는데, 이 경우 데이터 불일치 가능성이 있다는 점이 고민되었습니다.  
→ 그래서 `create`, `update`, `delete` 동작이 수행될 때마다 자동으로 파일 저장이 되도록 구현했고,  
`PostRepository`가 초기화될 때 `PostFileHandler`를 통해 파일에서 데이터를 불러와 메모리 리스트를 구성하도록 리팩토링했습니다.  

### 3. ID 생성 책임을 어디에 둘 것인가
처음에는 단순히 Service나 Repository에서 ID를 `++` 연산자로 증가시키는 구조였지만,  
이렇게 하면 외부에서 ID 생성 방식이 제각각이 될 수 있다는 우려가 생겼습니다.  
→ 그래서 `PostIdGenerator` 유틸 클래스를 만들어 `generateId()` 메서드만 공개하고,  
초기화 시엔 가장 큰 ID를 기준으로 다음 ID를 설정할 수 있도록 설계했습니다. 

## 🎯키워드 과제
https://www.notion.so/1d1adc440b9c8084b885f06b944023ad